### PR TITLE
Add basic CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,19 @@
+version: 2
+jobs:
+  build:
+    machine: true
+    steps:
+    - checkout
+
+    - run: |
+        wget -q $(curl -sS -H "Authorization: token $RELEASE_TOKEN" https://api.github.com/repos/giantswarm/architect/releases/latest | grep browser_download_url | head -n 1 | cut -d '"' -f 4)
+        chmod +x ./architect
+        ./architect version
+    - run: ./architect build
+    - store_test_results:
+        path: /tmp/results
+    - persist_to_workspace:
+        root: .
+        paths:
+          - ./shutdown-deferrer
+          - ./architect


### PR DESCRIPTION
Is this enough or is `architect deploy` needed to get the container pushed on Quay?