### PR TITLE
Add dummy deferrer endpoint

### DIFF
--- a/server/endpoint/deferrer/endpoint.go
+++ b/server/endpoint/deferrer/endpoint.go
@@ -1,0 +1,86 @@
+package deferrer
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	kitendpoint "github.com/go-kit/kit/endpoint"
+	kithttp "github.com/go-kit/kit/transport/http"
+)
+
+const (
+	// Method is the HTTP method this endpoint is registered for.
+	Method = "GET"
+	// Name identifies the endpoint. It is aligned to the package path.
+	Name = "deferrer"
+	// Path is the HTTP request path this endpoint is registered for.
+	Path = "/v1/defer/"
+)
+
+// Config represents the configuration used to create a lister endpoint.
+type Config struct {
+	// Dependencies.
+	Logger micrologger.Logger
+}
+
+type Endpoint struct {
+	logger micrologger.Logger
+}
+
+// New creates a new configured lister object.
+func New(config Config) (*Endpoint, error) {
+	// Dependencies.
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	e := &Endpoint{
+		logger: config.Logger,
+	}
+
+	return e, nil
+}
+
+func (e *Endpoint) Decoder() kithttp.DecodeRequestFunc {
+	return func(ctx context.Context, r *http.Request) (interface{}, error) {
+		return nil, nil
+	}
+}
+
+func (e *Endpoint) Encoder() kithttp.EncodeResponseFunc {
+	return func(ctx context.Context, w http.ResponseWriter, response interface{}) error {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		b, ok := response.([]byte)
+		if !ok {
+			return microerror.Mask(invalidResponseTypeError)
+		}
+		_, err := w.Write(b)
+		return err
+	}
+}
+
+func (e *Endpoint) Endpoint() kitendpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		return []byte("no"), nil
+	}
+}
+
+func (e *Endpoint) Method() string {
+	return Method
+}
+
+// Middlewares returns a slice of the middlewares used in this endpoint.
+func (e *Endpoint) Middlewares() []kitendpoint.Middleware {
+	return []kitendpoint.Middleware{}
+}
+
+func (e *Endpoint) Name() string {
+	return Name
+}
+
+func (e *Endpoint) Path() string {
+	return Path
+}

--- a/server/endpoint/deferrer/error.go
+++ b/server/endpoint/deferrer/error.go
@@ -1,0 +1,21 @@
+package deferrer
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var invalidResponseTypeError = &microerror.Error{
+	Kind: "invalidResponseTypeError",
+}
+
+// IsInvalidResponseType asserts invalidResponseTypeError.
+func IsInvalidResponseType(err error) bool {
+	return microerror.Cause(err) == invalidResponseTypeError
+}

--- a/server/server.go
+++ b/server/server.go
@@ -59,6 +59,7 @@ func New(config Config) (*Server, error) {
 			Viper:       config.Viper,
 
 			Endpoints: []microserver.Endpoint{
+				endpointCollection.Deferrer,
 				endpointCollection.Healthz,
 				endpointCollection.Version,
 			},


### PR DESCRIPTION
Simple dummy endpoint for deferrer.

GET /v1/defer -> "no"

This might seem a bit controversial in the way that "Sure, free to continue with shutdown" response is `no`, but it felt natural for me to name this in this way and when asking whether or not to defer shutdown, `no` is the answer to proceed straight away.

Towards https://github.com/giantswarm/giantswarm/issues/2993