### PR TITLE
Add `daemon` param to entrypoint command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,6 @@ RUN apk add --no-cache ca-certificates
 
 ADD ./shutdown-deferrer /shutdown-deferrer
 
-ENTRYPOINT ["/shutdown-deferrer", "daemon"]
+ENTRYPOINT ["/shutdown-deferrer"]
+
+CMD ["daemon"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,4 @@ RUN apk add --no-cache ca-certificates
 
 ADD ./shutdown-deferrer /shutdown-deferrer
 
-ENTRYPOINT ["/shutdown-deferrer"]
+ENTRYPOINT ["/shutdown-deferrer", "daemon"]


### PR DESCRIPTION
Executing just /shutdown-deferrer prints help and exits. It needs
`daemon` parameter in order to start the service.