### PR TITLE
Wire up deferrer service to endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.8
 
-RUN apk add --no-cache ca-certificates curl
+RUN apk add --no-cache bash ca-certificates coreutils curl
 
 ADD ./shutdown-deferrer /shutdown-deferrer
 ADD ./pre-shutdown-hook /pre-shutdown-hook

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM alpine:3.8
 RUN apk add --no-cache ca-certificates
 
 ADD ./shutdown-deferrer /shutdown-deferrer
+ADD ./pre-shutdown-hook /pre-shutdown-hook
 
 ENTRYPOINT ["/shutdown-deferrer"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.8
 
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates curl
 
 ADD ./shutdown-deferrer /shutdown-deferrer
 ADD ./pre-shutdown-hook /pre-shutdown-hook

--- a/pre-shutdown-hook
+++ b/pre-shutdown-hook
@@ -6,6 +6,8 @@ then
     exit 1
 fi
 
+# In order to guarantee correct behavior, this poll_interval should be equal to
+# one defined in k8s-kvm qemu-shutdown script.
 poll_interval=5
 poll_timeout=600
 shutdown_deferrer_url=$1
@@ -20,6 +22,10 @@ do
     echo "GET /v1/defer: $defer"
     poll_timeout=$(/usr/bin/expr $poll_timeout - $poll_interval)
 done
+
+# Small delay before exit so that k8s-kvm preStop hook has chance to do last
+# defer query.
+sleep (/usr/bin/expr $poll_interval + 1)
 
 # Return successful exit status to k8s
 exit 0

--- a/pre-shutdown-hook
+++ b/pre-shutdown-hook
@@ -20,3 +20,5 @@ do
     echo "GET /v1/defer: $defer"
     poll_timeout=$(/usr/bin/expr $poll_timeout - $poll_interval)
 done
+
+exit 0

--- a/pre-shutdown-hook
+++ b/pre-shutdown-hook
@@ -21,4 +21,5 @@ do
     poll_timeout=$(/usr/bin/expr $poll_timeout - $poll_interval)
 done
 
+# Return successful exit status to k8s
 exit 0

--- a/pre-shutdown-hook
+++ b/pre-shutdown-hook
@@ -25,7 +25,7 @@ done
 
 # Small delay before exit so that k8s-kvm preStop hook has chance to do last
 # defer query.
-sleep (/usr/bin/expr $poll_interval + 1)
+sleep $(/usr/bin/expr $poll_interval + 1)
 
 # Return successful exit status to k8s
 exit 0

--- a/pre-shutdown-hook
+++ b/pre-shutdown-hook
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+if [ $# -eq 0 ]
+then
+    echo "usage: $0 <shutdown-deferrer url>"
+    exit 1
+fi
+
+poll_interval=5
+poll_timeout=600
+shutdown_deferrer_url=$1
+
+# Poll shutdown-deferrer service in order to wait for proper node draining
+# before shutdown.
+defer="true"
+while [ "$defer" = "true" -a $poll_timeout -gt 0 ]
+do
+    sleep $poll_interval
+    defer=$(/usr/bin/curl -qsS $shutdown_deferrer_url)
+    echo "GET /v1/defer: $defer"
+    poll_timeout=$(/bin/expr $poll_timeout - $poll_interval)
+done

--- a/pre-shutdown-hook
+++ b/pre-shutdown-hook
@@ -18,5 +18,5 @@ do
     sleep $poll_interval
     defer=$(/usr/bin/curl -qsS $shutdown_deferrer_url)
     echo "GET /v1/defer: $defer"
-    poll_timeout=$(/bin/expr $poll_timeout - $poll_interval)
+    poll_timeout=$(/usr/bin/expr $poll_timeout - $poll_interval)
 done

--- a/pre-shutdown-hook
+++ b/pre-shutdown-hook
@@ -9,7 +9,7 @@ fi
 # In order to guarantee correct behavior, this poll_interval should be equal to
 # one defined in k8s-kvm qemu-shutdown script.
 poll_interval=5
-poll_timeout=600
+poll_timeout=120
 shutdown_deferrer_url=$1
 
 # Poll shutdown-deferrer service in order to wait for proper node draining

--- a/server/endpoint/endpoint.go
+++ b/server/endpoint/endpoint.go
@@ -27,7 +27,8 @@ func New(config Config) (*Endpoint, error) {
 	var deferrerEndpoint *deferrer.Endpoint
 	{
 		c := deferrer.Config{
-			Logger: config.Logger,
+			Deferrer: config.Service.Deferrer,
+			Logger:   config.Logger,
 		}
 
 		deferrerEndpoint, err = deferrer.New(c)


### PR DESCRIPTION
Use actual deferrer.Service to return value for deferring request.

NOTE: This changes response from static "no" to being "true" or "false"
depending on whether or not shutdown should be deferred.

Also added `pre-shutdown-hook` so that `shutdown-deferrer` container is not terminated before node is drained and `k8s-kvm` is terminated.

Towards https://github.com/giantswarm/giantswarm/issues/2993#issuecomment-429270302